### PR TITLE
Support specific conda version as arg

### DIFF
--- a/centos6_gcc44/Dockerfile
+++ b/centos6_gcc44/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:centos6
 MAINTAINER Continuum Analytics, Inc. <conda@continuum.io>
+ARG CONDA_VERSION=4.3.11
 
 RUN yum -y update; yum clean all \
 
@@ -38,7 +39,7 @@ RUN wget --quiet http://mirror.ox.ac.uk/sites/ctan.org/systems/texlive/tlnet/ins
     && TEXLIVE_INSTALL_PREFIX=/opt/texlive ./install-tl \
     && rm -rf /temp
 
-RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.3.11-Linux-x86_64.sh -O ~/miniconda.sh \
+RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh \
     && /bin/bash ~/miniconda.sh -b -p /opt/conda \
     && rm ~/miniconda.sh
 

--- a/miniconda2/centos6/Dockerfile
+++ b/miniconda2/centos6/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:centos6
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN yum -y update \
     && yum -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local/envs/_conda_ \
     && rm -rf /tmp/miniconda.sh \
     && pushd /usr/local/bin \

--- a/miniconda2/centos7/Dockerfile
+++ b/miniconda2/centos7/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:centos7
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN yum -y update \
     && yum -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local/ \
     && rm -rf /tmp/miniconda.sh \
     && conda install -y python=2 \

--- a/miniconda2/debian/Dockerfile
+++ b/miniconda2/debian/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:latest
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
     && conda install -y python=2 \

--- a/miniconda3/centos6/Dockerfile
+++ b/miniconda3/centos6/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:centos6
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN yum -y update \
     && yum -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local/ \
     && rm -rf /tmp/miniconda.sh \
     && conda install -y python=3 \

--- a/miniconda3/centos7/Dockerfile
+++ b/miniconda3/centos7/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:centos7
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN yum -y update \
     && yum -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local/ \
     && rm -rf /tmp/miniconda.sh \
     && conda install -y python=3 \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:latest
 MAINTAINER Conda Development Team <conda@continuum.io>
+ARG CONDA_VERSION=latest
 
 RUN apt-get -qq update && apt-get -qq -y install curl bzip2 \
-    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
+    && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -bfp /usr/local \
     && rm -rf /tmp/miniconda.sh \
     && conda install -y python=3 \


### PR DESCRIPTION
Makes it nice and easy to publish specific versions of conda, e.g.:

```
cd miniconda2/centos7
docker build --build-arg CONDA_VERSION=4.3.27.1 .
```

(mostly because I want to use your centos7 minimal image with a specific version of conda :) )