### PR TITLE
add conda-package-handling dep

### DIFF
--- a/condatest/linux-64-python2.7/Dockerfile
+++ b/condatest/linux-64-python2.7/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.s
     && sudo bash /tmp/miniconda.sh -bfp /opt/conda/ \
     && rm -rf /tmp/miniconda.sh \
     && sudo /opt/conda/bin/conda install -y -c conda-canary -c defaults -c conda-forge \
-        conda \
+        conda conda-package-handling \
         python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
         anaconda-client nbformat \
         pytest pytest-cov pytest-timeout mock responses pexpect \

--- a/condatest/linux-64-python3.6/Dockerfile
+++ b/condatest/linux-64-python3.6/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.s
     && sudo bash /tmp/miniconda.sh -bfp /opt/conda/ \
     && rm -rf /tmp/miniconda.sh \
     && sudo /opt/conda/bin/conda install -y -c conda-canary -c defaults -c conda-forge \
-        conda \
+        conda conda-package-handling \
         python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
         anaconda-client nbformat \
         pytest pytest-cov pytest-timeout mock responses pexpect xonsh \

--- a/condatest/linux-64-python3.7/Dockerfile
+++ b/condatest/linux-64-python3.7/Dockerfile
@@ -2,8 +2,10 @@ FROM circleci/golang
 MAINTAINER Conda Development Team <conda@continuum.io>
 
 #  $ docker build . -t condatest/linux-64-python-3.7:latest
+#  $ docker run --rm -it condatest/linux-64-python-3.7:latest /opt/conda/bin/conda info
+#  $ docker run --rm -it condatest/linux-64-python-3.7:latest /opt/conda/bin/conda list
+#  $ docker run --rm -it condatest/linux-64-python-3.7:latest /bin/bash
 #  $ docker push condatest/linux-64-python-3.7
-#  $ docker run --rm -it condatest/linux-64-python-3.7 /bin/bash
 
 # NOTE: sudo is used in this Dockerfile because the circleci images default user is NOT root
 
@@ -26,46 +28,26 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add - 
 
 ENV PYTHON_VERSION 3.7
 
-# conda bootstrap
+# conda and test dependencies
 RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
     && sudo bash /tmp/miniconda.sh -bfp /opt/conda/ \
-    && rm -rf /tmp/miniconda.sh
-
-
-# conda test dependencies
-RUN sudo /opt/conda/bin/conda create -p /opt/conda-py37 -y -c defaults -c conda-forge \
-        python=$PYTHON_VERSION  \
-    && sudo /opt/conda/bin/conda clean --all --yes
-
-# conda test dependencies 2
-RUN sudo /opt/conda-py37/bin/pip install \
-        pycosat requests ruamel.yaml \
+    && rm -rf /tmp/miniconda.sh \
+    && sudo /opt/conda/bin/conda install -y -c conda-canary -c defaults -c conda-forge \
+        conda conda-package-handling \
+        python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
         anaconda-client nbformat \
         pytest pytest-cov pytest-timeout mock responses pexpect xonsh \
         flake8 \
+    && sudo /opt/conda/bin/conda clean --all --yes
+
+RUN sudo /opt/conda/bin/pip install codecov radon \
     && sudo rm -rf ~root/.cache/pip
 
-RUN sudo /opt/conda-py37/bin/pip install codecov radon \
-    && sudo rm -rf ~root/.cache/pip
-
-RUN sudo rm -rf /opt/conda \
-    && cd /opt && sudo ln -s conda-py37 conda
-
-RUN sudo git clone https://github.com/conda/conda /var/conda \
-    && sudo /opt/conda/bin/pip install -e /var/conda
-
-RUN sudo su root -c "/opt/conda/bin/conda init"
-
-# RUN git clone https://github.com/conda/conda /go/conda \
-#     && cd /go/conda \
-#     && eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)" \
-#     && conda info
-
-# # conda-build and test dependencies
-# RUN sudo /opt/conda/bin/conda install -y -c defaults -c conda-forge \
-#         conda-build patch git \
-#         perl pytest-xdist pytest-mock \
-#         anaconda-client \
-#         filelock jinja2 conda-verify pkginfo \
-#         glob2 beautifulsoup4 chardet pycrypto \
-#     && sudo /opt/conda/bin/conda clean --all --yes
+# conda-build and test dependencies
+RUN sudo /opt/conda/bin/conda install -y -c defaults -c conda-forge \
+        conda-build patch git \
+        perl pytest-xdist pytest-catchlog pytest-mock \
+        anaconda-client \
+        filelock jinja2 conda-verify pkginfo \
+        glob2 beautifulsoup4 chardet pycrypto \
+    && sudo /opt/conda/bin/conda clean --all --yes


### PR DESCRIPTION
This adds a new dep for the new package format.  It also undoes some of the python 3.7 file, opting instead to just copy the file that has been in use for 3.6 and change versions to 3.7.